### PR TITLE
bark_fbanks.py does not apply nfft and fs to frequency converter functions

### DIFF
--- a/spafe/fbanks/bark_fbanks.py
+++ b/spafe/fbanks/bark_fbanks.py
@@ -71,7 +71,7 @@ def bark_filter_banks(nfilts=20,
     bark_points = np.linspace(low_bark, high_bark, nfilts + 4)
 
     # we use fft bins, so we have to convert from Bark to fft bin number
-    bins = np.floor(bark2fft(bark_points))
+    bins = np.floor(bark2fft(bark_points, fs, nfft))
     fbank = np.zeros([nfilts, nfft // 2 + 1])
 
     # init scaler
@@ -92,6 +92,6 @@ def bark_filter_banks(nfilts=20,
 
         for i in range(int(bins[j - 2]), int(bins[j + 2])):
             fc = bark_points[j]
-            fb = fft2bark(i)
+            fb = fft2bark(i, fs, nfft)
             fbank[j - 2, i] = c * Fm(fb, fc)
     return np.abs(fbank)

--- a/spafe/utils/converters.py
+++ b/spafe/utils/converters.py
@@ -35,7 +35,7 @@ def erb2hz(fe):
     return ((fe / 24.7) - 1) * (1000. / 4.37)
 
 
-def fft2erb(fft, fs=16000, nfft=512):
+def fft2erb(fft, fs, nfft):
     """
     Convert Bark frequencies to Hz.
 
@@ -48,13 +48,14 @@ def fft2erb(fft, fs=16000, nfft=512):
     return hz2erb((fft * fs) / (nfft + 1))
 
 
-def erb2fft(fb, fs=16000, nfft=512):
+def erb2fft(fb, fs, nfft):
     """
     Convert Bark frequencies to fft bins.
 
     Args:
-        fb (np.array): frequencies in Bark [Bark].
-
+        fb (np.array):  frequencies in Bark [Bark].
+        fs (int):       sample rate/ sampling frequency of the signal.
+        nfft (int):     the FFT size.
     Returns:
         (np.array) : fft bin numbers.
     """
@@ -87,38 +88,42 @@ def bark2hz(fb):
     return 600. * np.sinh(fb / 6.)
 
 
-def fft2hz(fft, fs=16000, nfft=512):
+def fft2hz(fft, fs, nfft):
     """
     Convert Bark frequencies to Hz.
 
     Args:
-        fft (np.array) : fft bin numbers.
-
+        fft (np.array): fft bin numbers.
+        fs (int):       sample rate/ sampling frequency of the signal.
+        nfft (int):     the FFT size.
     Returns:
         (np.array): frequencies in Bark [Bark].
     """
     return (fft * fs) / (nfft + 1)
 
 
-def hz2fft(fb, fs=16000, nfft=512):
+def hz2fft(fb, fs, nfft):
     """
     Convert Bark frequencies to fft bins.
 
     Args:
-        fb (np.array): frequencies in Bark [Bark].
-
+        fb (np.array):  frequencies in Bark [Bark].
+        fs (int):       sample rate/ sampling frequency of the signal.
+        nfft (int):     the FFT size.
     Returns:
         (np.array) : fft bin numbers.
     """
     return (nfft + 1) * fb / fs
 
 
-def fft2bark(fft, fs=16000, nfft=512):
+def fft2bark(fft, fs, nfft):
     """
     Convert Bark frequencies to Hz.
 
     Args:
-        fft (np.array) : fft bin numbers.
+        fft (np.array): fft bin numbers.
+        fs (int):       sample rate/ sampling frequency of the signal.
+        nfft (int):     the FFT size.
 
     Returns:
         (np.array): frequencies in Bark [Bark].
@@ -126,13 +131,14 @@ def fft2bark(fft, fs=16000, nfft=512):
     return hz2bark((fft * fs) / (nfft + 1))
 
 
-def bark2fft(fb, fs=16000, nfft=512):
+def bark2fft(fb, fs, nfft):
     """
     Convert Bark frequencies to fft bins.
 
     Args:
-        fb (np.array): frequencies in Bark [Bark].
-
+        fb (np.array):  frequencies in Bark [Bark].
+        fs (int):       sample rate/ sampling frequency of the signal.
+        nfft (int):     the FFT size.
     Returns:
         (np.array) : fft bin numbers.
     """


### PR DESCRIPTION
bark_fbanks.py did not apply parameters nfft and fs to frequency converter functions. This was fixed.

It seems not reasonable at all to allow optional arguments in the converter functions?

Existing tests were all passing with the suggested change.

