### PR TITLE
fix: non-int issue and remove useless variables

### DIFF
--- a/spafe/utils/preprocessing.py
+++ b/spafe/utils/preprocessing.py
@@ -77,13 +77,11 @@ def framing(sig, fs=16000, win_len=0.025, win_hop=0.01):
         raise ParameterError(ErrorMsgs["win_len_win_hop_comparison"])
 
     # compute frame length and frame step (convert from seconds to samples)
-    frame_length = win_len * fs
-    frame_step = win_hop * fs
-    signal_length = len(sig)
-    frames_overlap = frame_length - frame_step
+    frame_length = int(win_len * fs)
+    frame_step = int(win_hop * fs)
 
     # make sure to use integers as indices
-    frames = stride_trick(sig, int(frame_length), int(frame_step))
+    frames = stride_trick(sig, frame_length, frame_step)
     if len(frames[-1]) < frame_length:
         frames[-1] = np.append(frames[-1], np.array([0]*(frame_length - len(frames[0]))))
 


### PR DESCRIPTION
#### Reference Issue
closes https://github.com/SuperKogito/spafe/issues/14

#### What does this implement/fix? Explain your changes.
- Cast to int `frame_length` and `frame_step` as suggested from the issue.
- Remove unused variables

#### Any other comments?

Thanks https://github.com/aacarneiro/spafe/commit/95a8c785a7982db697a2ee5ff9f57845f5f56f5f @aacarneiro
