### PR TITLE
Replace np.append method with scipy.signal.lfilter (preemphasis)

### DIFF
--- a/spafe/utils/preprocessing.py
+++ b/spafe/utils/preprocessing.py
@@ -6,9 +6,11 @@
   For a copy, see <https://github.com/SuperKogito/spafe/blob/master/LICENSE>.
 
 """
+
 from typing import Tuple
 
 import numpy as np
+from scipy.signal import lfilter
 from dataclasses import dataclass
 from typing_extensions import Literal
 
@@ -67,7 +69,7 @@ def pre_emphasis(sig: np.ndarray, pre_emph_coeff: float = 0.97) -> np.ndarray:
 
             y[t] = x[t] - \\alpha \\times x[t-1]
     """
-    return np.append(sig[0], sig[1:] - pre_emph_coeff * sig[:-1])
+    return lfilter([1, -pre_emph_coeff], [1], sig)
 
 
 def stride_trick(a: np.ndarray, stride_length: int, stride_step: int) -> np.ndarray:


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Scipy implementation of a first-order FIR filter has better performance and efficiency of the filtering process. The lfilter method provides a more optimized implementation, resulting in faster processing times.

#### Any other comments?

Recently I have started working on an audio feature extraction library as a university project. Read about the pre-emphasis process, found out that one way is to simply apply a first-order high-pass FIR filter and so looked up some implementations, like in spafe, seen that it uses np.append, tried lfilter instead, saw it's a bit faster. Now trying to contribute with a main goal to see if my observations are correct :D
